### PR TITLE
Fix #2 "resultSet.getRows() is always empty"

### DIFF
--- a/src/main/java/io/vertx/ext/sql/ResultSet.java
+++ b/src/main/java/io/vertx/ext/sql/ResultSet.java
@@ -114,6 +114,7 @@ public class ResultSet {
         for (int i = 0; i < cols; i++) {
           row.put(columnNames.get(i), result.getValue(i));
         }
+        rows.add(row);
       }
     }
     return rows;

--- a/src/test/java/io/vertx/ext/sql/test/ResultSetTest.java
+++ b/src/test/java/io/vertx/ext/sql/test/ResultSetTest.java
@@ -51,6 +51,7 @@ public class ResultSetTest {
     assertEquals(results, rs.getResults());
 
     List<JsonObject> rows = rs.getRows();
+    assertEquals(numRows, rs.getRows().size());
     int index = 0;
     for (JsonObject row: rows) {
       JsonArray result = results.get(index);


### PR DESCRIPTION
This fixes #2 
In the loop to generate the rows list, the rows are generated but never added to the list.
