### PR TITLE
Allow raw types from the async-sql framework to propagate up.

### DIFF
--- a/src/main/java/io/vertx/ext/sql/ResultSet.java
+++ b/src/main/java/io/vertx/ext/sql/ResultSet.java
@@ -5,7 +5,9 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the results of a SQL query.
@@ -128,10 +130,11 @@ public class ResultSet {
       rows = new ArrayList<>(results.size());
       int cols = columnNames.size();
       for (JsonArray result: results) {
-        JsonObject row = new JsonObject();
+        Map<String, Object> rowMap = new HashMap<>(cols);
         for (int i = 0; i < cols; i++) {
-          row.put(columnNames.get(i), result.getValue(i));
+          rowMap.put(columnNames.get(i), result.getValue(i));
         }
+        JsonObject row = new JsonObject(rowMap);
         rows.add(row);
       }
     }


### PR DESCRIPTION
Converting the raw object types that come from the mauricio driver to strings to only have the application layer convert them back to their types is a terrible implementation. Not only do you get the performance hit, but it then forces the application layer to be littered with conversions. The only reason this is happening is because the JsonArray and JsonObject will check the values type and restrict it to an allowable subset. They do however not do the type checking when they are instantiated with a list or map.

There is a pull request for the vertx-mysql-postgres-client framework as well.
