### PR TITLE
minor javadoc fix

### DIFF
--- a/src/main/java/io/vertx/ext/sql/SQLConnection.java
+++ b/src/main/java/io/vertx/ext/sql/SQLConnection.java
@@ -132,7 +132,7 @@ public interface SQLConnection extends AutoCloseable {
   /**
    * Calls the given SQL <code>PROCEDURE</code> which returns the result from the procedure.
    *
-   * @param sql  the SQL to execute. For example <code>{call getEmpName (?, ?)}</code>.
+   * @param sql  the SQL to execute. For example <code>{call getEmpName}</code>.
    * @param resultHandler  the handler which is called once the operation completes. It will return a {@code ResultSet}.
    *
    * @see java.sql.CallableStatement#execute(String)


### PR DESCRIPTION
Javadoc example should be without parameters for `#call(String, Handler)` as opposed to `#call(String, JsonArray, Handler)`